### PR TITLE
stream_name: Allow to override the default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ Role Variables
 
 List of logs with the following keys
 
-| Name       | Description            | Required
-|------------|------------------------|---------
-| file       | Full path to log file  | Yes
-| format     | Datetime format        | No
-| group_name | CloudWatch Log Group   | Yes
-
-Note: extra_logs is identical to logs.
-The two variables are merged in the template in order to allow the definition of both 'system' logs and 'specific' logs.
+| Name        | Description                | Required | Default
+|-------------|----------------------------|----------|---------
+| file        | Full path to log file      | Yes      |
+| format      | Datetime format            | No       | None
+| group_name  | CloudWatch Log Group       | Yes      |
+| stream_name | CloudWatch Log Stream Name | No       | The instance id
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs AWS CloudWatch Log Agent
 Requirements
 ------------
 
-Requires ec2_facts. 
+Requires ec2_facts.
 
 Role Variables
 --------------
@@ -25,7 +25,7 @@ The two variables are merged in the template in order to allow the definition of
 Dependencies
 ------------
 
-This role has no dependencies. 
+This role has no dependencies.
 
 Example Playbook
 ----------------
@@ -36,6 +36,7 @@ Example Playbook
           - file: /var/log/auth.log
             format: "%b %d %H:%M:%S"
             group_name: "auth"
+            stream_name: "auth-stream"
           - file: /home/ubuntu/.bash_history
             group_name: "bash_history"
       roles:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for ansible-aws-cloudwatch-logs-agent
 extra_logs: {}
+stream_name: "{{ ansible_ec2_instance_id }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ansible-aws-cloudwatch-logs-agent
 extra_logs: {}
-stream_name: "{{ ansible_ec2_instance_id }}"
+stream_name: "{ instance_id }"

--- a/templates/etc/awslogs/awslogs.conf.j2
+++ b/templates/etc/awslogs/awslogs.conf.j2
@@ -123,5 +123,5 @@ datetime_format = {{ log.format }}
 {% endif %}
 file = {{ log.file }}
 log_group_name = {{ log.group_name }}
-log_stream_name = {instance_id}
+log_stream_name = {{ log.stream_name | default(stream_name) }}
 {% endfor %}


### PR DESCRIPTION
Currently the template's value for stream_name was always
{ instance_id } without the possibility to override it. It is now
possible to whether set this value in the dict, whether change the default
value globally.