### PR TITLE
extra_logs: Add capacity to have 2 variables to define logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ List of logs with the following keys
 | format     | Datetime format        | No
 | group_name | CloudWatch Log Group   | Yes
 
+Note: extra_logs is identical to logs.
+The two variables are merged in the template in order to allow the definition of both 'system' logs and 'specific' logs.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for ansible-aws-cloudwatch-logs-agent
+extra_logs: {}

--- a/templates/etc/awslogs/awslogs.conf.j2
+++ b/templates/etc/awslogs/awslogs.conf.j2
@@ -116,7 +116,7 @@ state_file = /var/awslogs/state/agent-state
 #  %c           Locale's appropriate date and time representation.                                      Tue Aug 16 21:30:00 1988 (en_US)
 # ----------------------------------------------------------------------------------------------------------------------
 
-{% for log in logs %}
+{% for log in logs|list + extra_logs|list %}
 [{{ log.file }}]
 {% if log.format is defined %}
 datetime_format = {{ log.format }}


### PR DESCRIPTION
This is a useful feature to have when working with 'common' logs and 'specific' logs.

For example we might to have a centralised logs variable to define system's logs: bash history, syslog, auth log, etc. And have another variable for specific logs for a server/application: php logs, apache/nginx logs, new_relic logs, etc.