### PR TITLE
debian_logrotate: override logrotate.d/awslogs for debian

### DIFF
--- a/tasks/DebianInstall.yml
+++ b/tasks/DebianInstall.yml
@@ -9,3 +9,11 @@
 
 - name: "Install AWS CloudWatch Logs Agent (Debian)."
   shell: python /tmp/awslogs-agent-setup.py -n -r {{ ansible_ec2_placement_region }} -c /etc/awslogs/awslogs.conf
+
+- name: "Override /etc/logrotate.d/awslogs"
+  template:
+    src: etc/logrotate.d/awslogs_debian.j2
+    dest: /etc/logrotate.d/awslogs
+    owner: root
+    group: root
+    mode: 0644

--- a/templates/etc/logrotate.d/awslogs_debian.j2
+++ b/templates/etc/logrotate.d/awslogs_debian.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+# Override of logrotate file https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
+
+/var/log/awslogs.log {
+    su root root
+    missingok
+    notifempty
+    size 100M
+    create 0600 root root
+    delaycompress
+    compress
+    rotate 4
+    postrotate
+        service awslogs restart > /dev/null
+    endscript
+}


### PR DESCRIPTION
`/etc/logrotate.d/awslogs` file for debian come from the python script
https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py

This script generate logrotate config containing

```
        postrotate
                 service awslogs restart
        endscript
```

Add template on this file to allow ansible to configure it as needed in your system.

This template also fix the `postrotate` with a `> /dev/null` to avoid cron sending mails

```
/etc/cron.daily/logrotate:
Stopping system awslogs daemon
Starting system awslogs daemon
```

As it's already done by debian package for others daemon like rsyslog

```
/var/log/syslog
{
        rotate 7
        daily
        missingok
        notifempty
        delaycompress
        compress
        postrotate
                invoke-rc.d rsyslog rotate > /dev/null
        endscript
}
```