### PR TITLE
Fix broken endpoint

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ansible-aws-cloudwatch-logs-agent
 extra_logs: {}
-stream_name: "{ instance_id }"
+stream_name: "{instance_id}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,21 @@
   include: "DebianInstall.yml"
   when: ansible_os_family == "Debian"
 
+- name: "Determine region of the instance"
+  shell: curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -e '{ print $3 }' | sed 's/"//g'
+  register: aws_region_cmd
+
+- set_fact:
+    aws_region: "{{ aws_region_cmd.stdout }}"
+
+- name: "Set region for Cloudwatch endpoint"
+  template:
+    src: templates/etc/aws.conf.j2
+    dest: /var/awslogs/etc/aws.conf
+    owner: root
+    group: root
+    mode: 0600
+
 - name: "Restart awslogs service."
   service:
     name: awslogs

--- a/templates/etc/aws.conf.j2
+++ b/templates/etc/aws.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+[plugins]
+cwlogs = cwlogs
+[default]
+region = {{ aws_region }}


### PR DESCRIPTION
When using eu-west-2 region (maybe other regions too, but not verified) the logs endpoint was incorrect causing all log forwarding to fail.  The default seemed to be taken from the AZ name, rather than the region name.  I have added a fact and template to fix this.

I also discovered that the default stream name was not properly interpolating because of spaces with the braces.  My second commit correct this.