### PR TITLE
Ensure awslogs starts at boot

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,4 @@
   service:
     name: awslogs
     state: restarted
+    enabled: yes


### PR DESCRIPTION
Simple change to ensure ``awslogs`` start at runtime