### PR TITLE
Adds ability to choose region

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for ansible-aws-cloudwatch-logs-agent
 extra_logs: {}
 stream_name: "{ instance_id }"
+aws_region: us-east-1

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: gather EC2 facts
+  ec2_facts:
+
 - name: "Make /var/awslogs/state/ directory"
   file:
     path: /var/awslogs/state/
@@ -14,3 +17,10 @@
     group: root
     mode: 0644
 
+- name: "Configure AWS CloudWatch Logs Agent - Region"
+  template:
+    src: etc/awslogs/awscli.conf.j2
+    dest: /etc/awslogs/awscli.conf
+    owner: root
+    group: root
+    mode: 0644

--- a/templates/etc/awslogs/awscli.conf.j2
+++ b/templates/etc/awslogs/awscli.conf.j2
@@ -1,0 +1,4 @@
+[plugins]
+cwlogs = cwlogs
+[default]
+region = {{ ansible_ec2_placement_region | default(aws_region) }}


### PR DESCRIPTION
This allows users to automatically set cloudwatch logs agent region based on EC2 Metadata but also allow them to override via variables/playbook, etc. 

Adds:

* ``awscli.conf.j2`` template
* ec2_facts (Amazon Linux/RedHat)
* ``aws_region`` default