### PR TITLE
Without el rpm

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,6 +1,39 @@
 ---
 
-- name: "Install CloudWatch Log Agent (RedHat)"
+- name: "Install CloudWatch Log Agent (Amazon)"
   yum:
     name: awslogs
     state: present
+  register: yum_result
+  ignore_errors: true
+
+- block:
+  - name: "Get ec2 facts (RedHat)."
+    action: ec2_facts
+
+  - name: "Download Install Script (RedHat)."
+    get_url:
+      url: https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
+      dest: /tmp/awslogs-agent-setup.py
+      mode: 550
+
+  - name: "Create /etc/awslogs (RedHat)."
+    file:
+      path: /etc/awslogs
+      state: directory
+      mode: 755
+
+  - name: "Configure Cloudwatch Log Agent."
+    include: "conf.yml"
+
+  - name: "Install AWS CloudWatch Logs Agent (RedHat)."
+    shell: python /tmp/awslogs-agent-setup.py -n -r {{ ansible_ec2_placement_region }} -c /etc/awslogs/awslogs.conf
+
+  - name: "Override /etc/logrotate.d/awslogs"
+    template:
+      src: etc/logrotate.d/awslogs_redhat.j2
+      dest: /etc/logrotate.d/awslogs
+      owner: root
+      group: root
+      mode: 0644
+  when: "yum_result.failed == true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,21 @@
   include: "DebianInstall.yml"
   when: ansible_os_family == "Debian"
 
+- name: "Determine region of the instance"
+  shell: curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -e '{ print $3 }' | sed 's/"//g'
+  register: aws_region_cmd
+
+- set_fact:
+    aws_region: "{{ aws_region_cmd.stdout }}"
+
+- name: "Set region for Cloudwatch endpoint"
+  template:
+    src: templates/etc/aws.conf.j2
+    dest: /var/awslogs/etc/aws.conf
+    owner: root
+    group: root
+    mode: 0600
+
 - name: "Restart awslogs service."
   service:
     name: awslogs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,15 +4,15 @@
   include: "RedHat.yml"
   when: ansible_os_family == "RedHat"
 
-- name: "Download Debian/Ubuntu Cloudwatch Log Agent Install Script."
-  include: "Debian.yml"
-  when: ansible_os_family == "Debian"
+- block:
+  - name: "Download Debian/Ubuntu Cloudwatch Log Agent Install Script."
+    include: "Debian.yml"
 
-- name: "Configure Cloudwatch Log Agent."
-  include: "conf.yml"
+  - name: "Configure Cloudwatch Log Agent."
+    include: "conf.yml"
 
-- name: "Install Debian/Ubuntu Cloudwatch Log Agent."
-  include: "DebianInstall.yml"
+  - name: "Install Debian/Ubuntu Cloudwatch Log Agent."
+    include: "DebianInstall.yml"
   when: ansible_os_family == "Debian"
 
 - name: "Determine region of the instance"

--- a/templates/etc/aws.conf.j2
+++ b/templates/etc/aws.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+[plugins]
+cwlogs = cwlogs
+[default]
+region = {{ aws_region }}

--- a/templates/etc/logrotate.d/awslogs_redhat.j2
+++ b/templates/etc/logrotate.d/awslogs_redhat.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+# Override of logrotate file https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
+
+/var/log/awslogs.log {
+    su root root
+    missingok
+    notifempty
+    size 100M
+    create 0600 root root
+    delaycompress
+    compress
+    rotate 4
+    postrotate
+        systemctl restart awslogs.service > /dev/null
+    endscript
+}


### PR DESCRIPTION
As far as I know, EL linux distros don't widely have an RPM for cloudwatch logs agent available to them.  I think only Amazon Linux has the RPM.   This results in the failure of the role to install the agent on these platforms.

This PR adds some code to install the agent on EL from the public s3 repo (in the same was as for the Debian os_family).