### PR TITLE
Check to see if already installed on RedHat

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -28,6 +28,8 @@
 
   - name: "Install AWS CloudWatch Logs Agent (RedHat)."
     shell: python /tmp/awslogs-agent-setup.py -n -r {{ ansible_ec2_placement_region }} -c /etc/awslogs/awslogs.conf
+    args:
+      creates: /etc/logrotate.d/awslogs
 
   - name: "Override /etc/logrotate.d/awslogs"
     template:

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -17,6 +17,16 @@
     group: root
     mode: 0644
 
+- name: "Make symlink for /var/awslogs/etc/awslogs.conf"
+  file:
+    src: /etc/awslogs/awslogs.conf
+    dest: /var/awslogs/etc/awslogs.conf
+    state: link
+    owner: root
+    group: root
+    mode: 0644
+    force: true
+
 - name: "Configure AWS CloudWatch Logs Agent - Region"
   template:
     src: etc/awslogs/awscli.conf.j2

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -17,16 +17,6 @@
     group: root
     mode: 0644
 
-- name: "Make symlink for /var/awslogs/etc/awslogs.conf"
-  file:
-    src: /etc/awslogs/awslogs.conf
-    dest: /var/awslogs/etc/awslogs.conf
-    state: link
-    owner: root
-    group: root
-    mode: 0644
-    force: true
-
 - name: "Configure AWS CloudWatch Logs Agent - Region"
   template:
     src: etc/awslogs/awscli.conf.j2


### PR DESCRIPTION
By checking the logrotate config file exists which is created in the next step, therefore after subsequent executions of the play we avoid running the `awslogs-agent-setup.py` each time.