### PR TITLE
Fix #16 region fail: Invalid endpoint

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,13 +15,6 @@
     include: "DebianInstall.yml"
   when: ansible_os_family == "Debian"
 
-- name: "Determine region of the instance"
-  shell: curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -e '{ print $3 }' | sed 's/"//g'
-  register: aws_region_cmd
-
-- set_fact:
-    aws_region: "{{ aws_region_cmd.stdout }}"
-
 - name: "Set region for Cloudwatch endpoint"
   template:
     src: templates/etc/aws.conf.j2

--- a/templates/etc/aws.conf.j2
+++ b/templates/etc/aws.conf.j2
@@ -2,4 +2,4 @@
 [plugins]
 cwlogs = cwlogs
 [default]
-region = {{ aws_region }}
+region = {{ ansible_ec2_placement_region | default(aws_region) }}


### PR DESCRIPTION
Remove the unnecessary fact to get the region since ansible is able to provide it.

Use ansible ansible_ec2_placement_region in the aws.conf.j2 template