### PR TITLE
Allow defining the agent's own logging level

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requires ec2_facts.
 Role Variables
 --------------
 
-List of logs with the following keys
+List of logs with the following keys:
 
 | Name        | Description                | Required | Default
 |-------------|----------------------------|----------|---------
@@ -19,6 +19,13 @@ List of logs with the following keys
 | format      | Datetime format            | No       | None
 | group_name  | CloudWatch Log Group       | Yes      |
 | stream_name | CloudWatch Log Stream Name | No       | The instance id
+
+Optional own_loglevel, maximal log level for the Log Agent's logs itself
+("debug", "info", "warning", "error" or "critical"). If this parameter is
+not defined, no specific logging configuration will take place and the
+default level (info) will be used. This parameter is very basic and does not
+allow flexible logging configuration, its only goal is to change the amount
+of logs going into the log agent's own logfile.
 
 Dependencies
 ------------
@@ -37,6 +44,7 @@ Example Playbook
             stream_name: "auth-stream"
           - file: /home/ubuntu/.bash_history
             group_name: "bash_history"
+        own_loglevel: info
       roles:
          - { role: dharrisio.aws-cloudwatch-logs }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requires ec2_facts.
 Role Variables
 --------------
 
-List of logs with the following keys:
+`logs`, `extra_logs`: list of logs with the following keys:
 
 | Name        | Description                | Required | Default
 |-------------|----------------------------|----------|---------
@@ -20,9 +20,9 @@ List of logs with the following keys:
 | group_name  | CloudWatch Log Group       | Yes      |
 | stream_name | CloudWatch Log Stream Name | No       | The instance id
 
-Optional own_loglevel, maximal log level for the Log Agent's logs itself
+`awslogs_loglevel`: maximal log level for the Log Agent's logs itself
 ("debug", "info", "warning", "error" or "critical"). If this parameter is
-not defined, no specific logging configuration will take place and the
+not specified, no specific logging configuration will take place and the
 default level (info) will be used. This parameter is very basic and does not
 allow flexible logging configuration, its only goal is to change the amount
 of logs going into the log agent's own logfile.
@@ -44,7 +44,7 @@ Example Playbook
             stream_name: "auth-stream"
           - file: /home/ubuntu/.bash_history
             group_name: "bash_history"
-        own_loglevel: info
+        awslogs_loglevel: info
       roles:
          - { role: dharrisio.aws-cloudwatch-logs }
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 extra_logs: {}
 stream_name: "{instance_id}"
 aws_region: us-east-1
+awslogs_loglevel: ""

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -24,7 +24,7 @@
     owner: root
     group: root
     mode: 0644
-  when: "'{{ awslogs_loglevel | default('') }}' != ''"
+  when: awslogs_loglevel != ""
 
 - name: "Configure AWS CloudWatch Logs Agent - Region"
   template:

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -17,6 +17,15 @@
     group: root
     mode: 0644
 
+- name: "Configure AWS CloudWatch Log Agent logging"
+  template:
+    src: etc/awslogs/awslogs.logging.conf.j2
+    dest: /etc/awslogs/awslogs.logging.conf
+    owner: root
+    group: root
+    mode: 0644
+  when: "'{{ own_loglevel | default('') }}' != ''"
+
 - name: "Configure AWS CloudWatch Logs Agent - Region"
   template:
     src: etc/awslogs/awscli.conf.j2

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -24,7 +24,7 @@
     owner: root
     group: root
     mode: 0644
-  when: "'{{ own_loglevel | default('') }}' != ''"
+  when: "'{{ awslogs_loglevel | default('') }}' != ''"
 
 - name: "Configure AWS CloudWatch Logs Agent - Region"
   template:

--- a/templates/etc/awslogs/awslogs.conf.j2
+++ b/templates/etc/awslogs/awslogs.conf.j2
@@ -35,7 +35,7 @@
 # Path to the CloudWatch Logs agent's state file. The agent uses this file to maintain
 # client side state across its executions.
 state_file = /var/awslogs/state/agent-state
-{% if own_loglevel | default('') != '' %}
+{% if awslogs_loglevel | default('') != '' %}
 logging_config_file = /etc/awslogs/awslogs.logging.conf
 {% endif %}
 

--- a/templates/etc/awslogs/awslogs.conf.j2
+++ b/templates/etc/awslogs/awslogs.conf.j2
@@ -35,6 +35,9 @@
 # Path to the CloudWatch Logs agent's state file. The agent uses this file to maintain
 # client side state across its executions.
 state_file = /var/awslogs/state/agent-state
+{% if own_loglevel | default('') != '' %}
+logging_config_file = /etc/awslogs/awslogs.logging.conf
+{% endif %}
 
 ## Each log file is defined in its own section. The section name doesn't
 ## matter as long as its unique within this file.

--- a/templates/etc/awslogs/awslogs.conf.j2
+++ b/templates/etc/awslogs/awslogs.conf.j2
@@ -35,7 +35,7 @@
 # Path to the CloudWatch Logs agent's state file. The agent uses this file to maintain
 # client side state across its executions.
 state_file = /var/awslogs/state/agent-state
-{% if awslogs_loglevel | default('') != '' %}
+{% if awslogs_loglevel != '' %}
 logging_config_file = /etc/awslogs/awslogs.logging.conf
 {% endif %}
 

--- a/templates/etc/awslogs/awslogs.logging.conf.j2
+++ b/templates/etc/awslogs/awslogs.logging.conf.j2
@@ -1,0 +1,67 @@
+#
+# Based on the logging configuration example from AWS documentation
+# https://docs.aws.amazon.com/fr_fr/AmazonCloudWatch/latest/logs/AgentReference.html
+#
+[loggers]
+keys=root,cwlogs,reader,publisher,event,batch,stream,watcher
+
+[handlers]
+keys=consoleHandler
+            
+[formatters]
+keys=simpleFormatter
+           
+[logger_root]
+level=INFO
+handlers=consoleHandler
+            
+[logger_cwlogs]
+level=INFO
+handlers=consoleHandler
+qualname=cwlogs.push
+propagate=0
+            
+[logger_reader]
+level={{ own_loglevel | upper }}
+handlers=consoleHandler
+qualname=cwlogs.push.reader
+propagate=0
+            
+[logger_publisher]
+level={{ own_loglevel | upper }}
+handlers=consoleHandler
+qualname=cwlogs.push.publisher
+propagate=0
+            
+[logger_event]
+level={{ own_loglevel | upper }}
+handlers=consoleHandler
+qualname=cwlogs.push.event
+propagate=0
+            
+[logger_batch]
+level={{ own_loglevel | upper }}
+handlers=consoleHandler
+qualname=cwlogs.push.batch
+propagate=0
+            
+[logger_stream]
+level={{ own_loglevel | upper }}
+handlers=consoleHandler
+qualname=cwlogs.push.stream
+propagate=0
+            
+[logger_watcher]
+level={{ own_loglevel | upper }}
+handlers=consoleHandler
+qualname=cwlogs.push.watcher
+propagate=0
+            
+[handler_consoleHandler]
+class=logging.StreamHandler
+level={{ own_loglevel | upper }}
+formatter=simpleFormatter
+args=(sys.stderr,)
+            
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(process)d - %(threadName)s - %(message)s

--- a/templates/etc/awslogs/awslogs.logging.conf.j2
+++ b/templates/etc/awslogs/awslogs.logging.conf.j2
@@ -22,44 +22,44 @@ qualname=cwlogs.push
 propagate=0
             
 [logger_reader]
-level={{ own_loglevel | upper }}
+level={{ awslogs_loglevel | upper }}
 handlers=consoleHandler
 qualname=cwlogs.push.reader
 propagate=0
             
 [logger_publisher]
-level={{ own_loglevel | upper }}
+level={{ awslogs_loglevel | upper }}
 handlers=consoleHandler
 qualname=cwlogs.push.publisher
 propagate=0
             
 [logger_event]
-level={{ own_loglevel | upper }}
+level={{ awslogs_loglevel | upper }}
 handlers=consoleHandler
 qualname=cwlogs.push.event
 propagate=0
             
 [logger_batch]
-level={{ own_loglevel | upper }}
+level={{ awslogs_loglevel | upper }}
 handlers=consoleHandler
 qualname=cwlogs.push.batch
 propagate=0
             
 [logger_stream]
-level={{ own_loglevel | upper }}
+level={{ awslogs_loglevel | upper }}
 handlers=consoleHandler
 qualname=cwlogs.push.stream
 propagate=0
             
 [logger_watcher]
-level={{ own_loglevel | upper }}
+level={{ awslogs_loglevel | upper }}
 handlers=consoleHandler
 qualname=cwlogs.push.watcher
 propagate=0
             
 [handler_consoleHandler]
 class=logging.StreamHandler
-level={{ own_loglevel | upper }}
+level={{ awslogs_loglevel | upper }}
 formatter=simpleFormatter
 args=(sys.stderr,)
             


### PR DESCRIPTION
The `awslogs_loglevel` new parameter allows setting the log level for the log agent itself.

If this parameter is absent, this role acts as before, without any specific
configuration for logging. It is completely backward-compatible.