### PR TITLE
Symlink after cwlogs has been installed Debian

### DIFF
--- a/tasks/DebianInstall.yml
+++ b/tasks/DebianInstall.yml
@@ -10,6 +10,16 @@
 - name: "Install AWS CloudWatch Logs Agent (Debian)."
   shell: python /tmp/awslogs-agent-setup.py -n -r {{ ansible_ec2_placement_region }} -c /etc/awslogs/awslogs.conf
 
+- name: "Make symlink for /var/awslogs/etc/awslogs.conf"
+  file:
+    src: /etc/awslogs/awslogs.conf
+    dest: /var/awslogs/etc/awslogs.conf
+    state: link
+    owner: root
+    group: root
+    mode: 0644
+    force: true
+
 - name: "Override /etc/logrotate.d/awslogs"
   template:
     src: etc/logrotate.d/awslogs_debian.j2


### PR DESCRIPTION
Since
https://github.com/dharrisio/ansible-role-aws-cloudwatch-logs-agent/commit/280010c81f5f85ef2f027f1f810e497c3bc5e4cf
The symlink is only done for a redhat install, nod Debian.