### PR TITLE
fix README example to use proper role location

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example Playbook
             group_name: "bash_history"
         awslogs_loglevel: info
       roles:
-         - { role: dharrisio.aws-cloudwatch-logs }
+         - { role: dharrisio.aws-cloudwatch-logs-agent }
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ default level (info) will be used. This parameter is very basic and does not
 allow flexible logging configuration, its only goal is to change the amount
 of logs going into the log agent's own logfile.
 
+`daemon_name`: Optional AWS log daemon service name, e.g. "awslogsd" for Amazon 
+Linux 2
+
 Dependencies
 ------------
 
@@ -44,6 +47,7 @@ Example Playbook
             stream_name: "auth-stream"
           - file: /home/ubuntu/.bash_history
             group_name: "bash_history"
+        daemon_name: "awslogsd"
         awslogs_loglevel: info
       roles:
          - { role: dharrisio.aws-cloudwatch-logs }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Role Name
 
 Installs AWS CloudWatch Log Agent
 
+forked from dbarrisio with some pull requests merged. The old one looked like it wasn't being supported anymore.
+
 Requirements
 ------------
 
@@ -51,7 +53,7 @@ Example Playbook
         daemon_name: "awslogsd"
         awslogs_loglevel: info
       roles:
-         - { role: dharrisio.aws-cloudwatch-logs-agent }
+         - { role: baileywickham.aws-cloudwatch-logs-agent }
 
 License
 -------
@@ -62,3 +64,4 @@ Author Information
 ------------------
 
 Created by David Harris
+Forked by Bailey Wickham

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Installs AWS CloudWatch Log Agent
 Requirements
 ------------
 
-Requires ec2_facts.
+Requires ec2_metadata_facts (so Asible must be > 2.4)
+
 
 Role Variables
 --------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ extra_logs: {}
 stream_name: "{instance_id}"
 aws_region: us-east-1
 awslogs_loglevel: ""
+daemon_name: "awslogs"

--- a/tasks/DebianInstall.yml
+++ b/tasks/DebianInstall.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Get ec2 facts (Debian)."
-  action: ec2_facts
+  ec2_metadata_facts:
 
 - name: "Update Package Lists (Debian)."
   apt:

--- a/tasks/DebianInstall.yml
+++ b/tasks/DebianInstall.yml
@@ -8,7 +8,7 @@
     update_cache: yes
 
 - name: "Install AWS CloudWatch Logs Agent (Debian)."
-  shell: python /tmp/awslogs-agent-setup.py -n -r {{ ansible_ec2_placement_region }} -c /etc/awslogs/awslogs.conf
+  shell: python3 /tmp/awslogs-agent-setup.py -n -r {{ ansible_ec2_placement_region }} -c /etc/awslogs/awslogs.conf
 
 - name: "Make symlink for /var/awslogs/etc/awslogs.conf"
   file:

--- a/tasks/DebianInstall.yml
+++ b/tasks/DebianInstall.yml
@@ -10,6 +10,16 @@
 - name: "Install AWS CloudWatch Logs Agent (Debian)."
   shell: python /tmp/awslogs-agent-setup.py -n -r {{ ansible_ec2_placement_region }} -c /etc/awslogs/awslogs.conf
 
+- name: "Make symlink for /var/awslogs/etc/awslogs.conf"
+  file:
+    src: /etc/awslogs/awslogs.conf
+    dest: /var/awslogs/etc/awslogs.conf
+    state: link
+    owner: root
+    group: root
+    mode: 0644
+    force: true
+
 - name: "Override /etc/logrotate.d/awslogs"
   template:
     src: etc/logrotate.d/awslogs_debian.j2

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -9,7 +9,7 @@
 
 - block:
   - name: "Get ec2 facts (RedHat)."
-    action: ec2_facts
+    ec2_metadata_facts:
 
   - name: "Download Install Script (RedHat)."
     get_url:

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: gather EC2 facts
-  ec2_facts:
+  ec2_metadata_facts:
 
 - name: "Make /var/awslogs/state/ directory"
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,6 @@
 
 - name: "Restart awslogs service."
   service:
-    name: awslogs
+    name: {{ daemon_name }}
     state: restarted
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,6 @@
 
 - name: "Restart awslogs service."
   service:
-    name: {{ daemon_name }}
+    name: "{{ daemon_name }}"
     state: restarted
     enabled: yes

--- a/templates/etc/awslogs/awslogs.conf.j2
+++ b/templates/etc/awslogs/awslogs.conf.j2
@@ -18,9 +18,9 @@
 # --- AGENT COMMANDS ---
 # To check or change the running status of the CloudWatch Logs Agent, use the following:
 #
-# To check running status: /etc/init.d/awslogs status
-# To stop the agent: /etc/init.d/awslogs stop
-# To start the agent: /etc/init.d/awslogs start
+# To check running status: /etc/init.d/{{ daemon_name }} status
+# To stop the agent: /etc/init.d/{{ daemon_name }} stop
+# To start the agent: /etc/init.d/{{ daemon_name }} start
 #
 # --- AGENT LOG OUTPUT ---
 # You can find logs for the agent in /var/log/awslogs.log

--- a/templates/etc/logrotate.d/awslogs_debian.j2
+++ b/templates/etc/logrotate.d/awslogs_debian.j2
@@ -11,6 +11,6 @@
     compress
     rotate 4
     postrotate
-        service awslogs restart > /dev/null
+        service {{ daemon_name }} restart > /dev/null
     endscript
 }

--- a/templates/etc/logrotate.d/awslogs_redhat.j2
+++ b/templates/etc/logrotate.d/awslogs_redhat.j2
@@ -11,6 +11,6 @@
     compress
     rotate 4
     postrotate
-        systemctl restart awslogs.service > /dev/null
+        systemctl restart {{ daemon_name }}.service > /dev/null
     endscript
 }


### PR DESCRIPTION
When using ansible galaxy to install, the role is located at `dharrisio.aws-cloudwatch-logs-agent`